### PR TITLE
Add Russian RSS feed list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ OPENAI_API_KEY=
 GEMINI_API_KEY=
 TINVEST_TOKEN=
 TINVEST_ENV=prod
+RSS_FEEDS="rbc=https://static.feed.rbc.ru/rbc/internal/rss.rbc.ru/rbc.ru/mainnews.rss,kommersant=https://www.kommersant.ru/RSS/section-economics.xml,cbr=http://www.cbr.ru/rss/RssNews,bankiru=https://www.banki.ru/news/lenta/?r1=rss&r2=news,finam_companies=https://www.finam.ru/analysis/conews/rsspoint/,finam_bonds=https://bonds.finam.ru/news/today/rss.asp,tass=https://tass.com/rss/v2.xml,profinance_stock=https://www.profinance.ru/fond.xml,profinance_economy=https://www.profinance.ru/econom.xml"
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=newsbot

--- a/README.md
+++ b/README.md
@@ -38,7 +38,13 @@ docker compose up --build
 - `GEMINI_API_KEY` – ключ Gemini для генерации краткого описания.
 - `TINVEST_TOKEN` – токен Tinkoff Invest API.
 - `TINVEST_ENV` – окружение `prod` или `sandbox` для Tinkoff Invest.
+- `RSS_FEEDS` – список RSS‑лент в формате `name=url,name=url`.
 - `POSTGRES_*` – параметры подключения к базе данных.
+
+По умолчанию бот использует следующие источники:
+```
+RSS_FEEDS="rbc=https://static.feed.rbc.ru/rbc/internal/rss.rbc.ru/rbc.ru/mainnews.rss,kommersant=https://www.kommersant.ru/RSS/section-economics.xml,cbr=http://www.cbr.ru/rss/RssNews,bankiru=https://www.banki.ru/news/lenta/?r1=rss&r2=news,finam_companies=https://www.finam.ru/analysis/conews/rsspoint/,finam_bonds=https://bonds.finam.ru/news/today/rss.asp,tass=https://tass.com/rss/v2.xml,profinance_stock=https://www.profinance.ru/fond.xml,profinance_economy=https://www.profinance.ru/econom.xml"
+```
 
 Полный список смотрите в `.env.example`.
 

--- a/src/config.py
+++ b/src/config.py
@@ -13,6 +13,26 @@ class Settings(BaseSettings):
     postgres_db: str = "newsbot"
     postgres_host: str = "db"
     postgres_port: int = 5432
+    rss_feeds: str = (
+        "rbc=https://static.feed.rbc.ru/rbc/internal/rss.rbc.ru/rbc.ru/mainnews.rss,"  # noqa: E501
+        "kommersant=https://www.kommersant.ru/RSS/section-economics.xml,"
+        "cbr=http://www.cbr.ru/rss/RssNews,"
+        "bankiru=https://www.banki.ru/news/lenta/?r1=rss&r2=news,"
+        "finam_companies=https://www.finam.ru/analysis/conews/rsspoint/,"
+        "finam_bonds=https://bonds.finam.ru/news/today/rss.asp,"
+        "tass=https://tass.com/rss/v2.xml,"
+        "profinance_stock=https://www.profinance.ru/fond.xml,"
+        "profinance_economy=https://www.profinance.ru/econom.xml"
+    )
+
+    @property
+    def rss_feeds_map(self) -> dict[str, str]:
+        feeds = {}
+        for item in self.rss_feeds.split(","):
+            if "=" in item:
+                name, url = item.split("=", 1)
+                feeds[name.strip()] = url.strip()
+        return feeds
 
     @property
     def postgres_dsn(self) -> str:

--- a/src/news/fetcher.py
+++ b/src/news/fetcher.py
@@ -6,12 +6,7 @@ from .dedup import is_new_article
 from ..llm.openai_runner import extract_json
 from ..db.migrate import AsyncSessionLocal
 from ..db import models
-
-RSS_FEEDS = {
-    "rbc": "https://rssexport.rbc.ru/rbcnews/news/30/full.rss",
-    "interfax": "https://www.interfax.ru/rss.asp",
-    "reuters_ru": "https://www.reuters.com/rssFeed/russianNews",
-}
+from ..config import settings
 
 
 async def process_entry(entry) -> None:
@@ -35,7 +30,7 @@ async def process_entry(entry) -> None:
 
 async def fetch_all() -> None:
     async with aiohttp.ClientSession() as session:
-        for url in RSS_FEEDS.values():
+        for url in settings.rss_feeds_map.values():
             async with session.get(url, timeout=30) as resp:
                 text = await resp.text()
                 parsed = feedparser.parse(text)


### PR DESCRIPTION
## Summary
- set a full list of default Russian RSS feeds in `Settings`
- document these feeds in README
- update `.env.example` with the same feed list

## Testing
- `poetry run ruff check src tests`
- `poetry run mypy src tests` *(fails: 9 errors in 9 files)*
- `poetry run pytest -s` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68441a1337c8832bab56eac78bc55e92